### PR TITLE
Sortering på plass

### DIFF
--- a/src/Forvaltningsportalen/ForvaltningsKartlag/ForvaltningsElement.js
+++ b/src/Forvaltningsportalen/ForvaltningsKartlag/ForvaltningsElement.js
@@ -17,12 +17,13 @@ import {
   ListItemText
 } from "@material-ui/core";
 
-const ForvaltningsEkspanderTopp = ({
+const ForvaltningsElement = ({
   kartlag,
   erAktivtLag,
   onUpdateLayerProp,
   handleShowCurrent,
-  show_current
+  show_current,
+  element
 }) => {
   let tittel = kartlag.tittel;
 
@@ -33,8 +34,8 @@ const ForvaltningsEkspanderTopp = ({
   const erSynlig = kartlag.erSynlig;
   const [open, setOpen] = useState(false);
   const [hasLegend, setHasLegend] = useState(true);
-
   if (!tittel) return null;
+
   return (
     <>
       <ListItem
@@ -129,4 +130,4 @@ const ForvaltningsEkspanderTopp = ({
   );
 };
 
-export default ForvaltningsEkspanderTopp;
+export default ForvaltningsElement;

--- a/src/Forvaltningsportalen/ForvaltningsKartlag/ForvaltningsGruppering.js
+++ b/src/Forvaltningsportalen/ForvaltningsKartlag/ForvaltningsGruppering.js
@@ -11,7 +11,7 @@ const ForvaltningsGruppering = ({
 }) => {
   return (
     <>
-      <h2>{element}</h2>
+      <h4 className="container_header">{element}</h4>
 
       {kartlag.map((element, index) => {
         return (

--- a/src/Forvaltningsportalen/ForvaltningsKartlag/ForvaltningsGruppering.js
+++ b/src/Forvaltningsportalen/ForvaltningsKartlag/ForvaltningsGruppering.js
@@ -1,0 +1,29 @@
+import React from "react";
+import ForvaltningsElement from "./ForvaltningsElement";
+
+const ForvaltningsGruppering = ({
+  kartlag,
+  erAktivtLag,
+  onUpdateLayerProp,
+  handleShowCurrent,
+  show_current,
+  element
+}) => {
+  return (
+    <>
+      <h2>{element}</h2>
+
+      {kartlag.map((element, index) => {
+        return (
+          <ForvaltningsElement
+            kartlag={element}
+            key={index}
+            onUpdateLayerProp={onUpdateLayerProp}
+          />
+        );
+      })}
+    </>
+  );
+};
+
+export default ForvaltningsGruppering;

--- a/src/Forvaltningsportalen/ForvaltningsKartlag/ForvaltningsKartlag.js
+++ b/src/Forvaltningsportalen/ForvaltningsKartlag/ForvaltningsKartlag.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { SettingsContext } from "SettingsContext";
-import ForvaltningsEkspanderTopp from "./ForvaltningsEkspanderTopp";
+import ForvaltningsGruppering from "./ForvaltningsGruppering";
 import { List } from "@material-ui/core";
 
 class ForvaltningsKartlag extends React.Component {
@@ -8,17 +8,40 @@ class ForvaltningsKartlag extends React.Component {
 
   render() {
     const { onUpdateLayerProp } = this.props;
-    const lag = this.props.kartlag;
+    let lag = this.props.kartlag;
+
+    let sortcriteria = "dataeier";
+    let sorted = {};
+    for (let item in lag) {
+      let criteria = lag[item][sortcriteria];
+      let new_list = [];
+
+      if (!criteria) {
+        criteria = "usortert";
+      }
+      if (sorted[criteria]) {
+        new_list = sorted[criteria];
+      }
+      new_list.push(lag[item]);
+      sorted[criteria] = new_list;
+    }
     return (
       <SettingsContext.Consumer>
         {context => (
           <>
             <List>
-              <DataEierLag
-                koder={lag}
-                onUpdateLayerProp={onUpdateLayerProp}
-                context={context}
-              ></DataEierLag>
+              {Object.keys(sorted)
+                .reverse()
+                .map(element => {
+                  return (
+                    <ForvaltningsGruppering
+                      kartlag={sorted[element]}
+                      element={element}
+                      key={element}
+                      onUpdateLayerProp={onUpdateLayerProp}
+                    />
+                  );
+                })}
             </List>
           </>
         )}
@@ -26,21 +49,5 @@ class ForvaltningsKartlag extends React.Component {
     );
   }
 }
-
-const DataEierLag = ({ context, koder, onUpdateLayerProp, ...props }) => {
-  // Denne funksjonen behandler hvert lag per dataeier
-  const keys = Object.keys(koder);
-  return keys.reverse().map(fkode => {
-    const kartlag = koder[fkode];
-    return (
-      <ForvaltningsEkspanderTopp
-        kartlag={kartlag}
-        key={fkode}
-        {...props}
-        onUpdateLayerProp={onUpdateLayerProp}
-      />
-    );
-  });
-};
 
 export default ForvaltningsKartlag;

--- a/src/Forvaltningsportalen/ForvaltningsKartlag/ForvaltningsKartlag.js
+++ b/src/Forvaltningsportalen/ForvaltningsKartlag/ForvaltningsKartlag.js
@@ -15,9 +15,8 @@ class ForvaltningsKartlag extends React.Component {
     for (let item in lag) {
       let criteria = lag[item][sortcriteria];
       let new_list = [];
-
       if (!criteria) {
-        criteria = "usortert";
+        criteria = "Ikke markert";
       }
       if (sorted[criteria]) {
         new_list = sorted[criteria];

--- a/src/kartlag.json
+++ b/src/kartlag.json
@@ -95,7 +95,7 @@
     "tittel": {
       "nb": "Landskap: LA-K"
     },
-    "dataeier": "ADB",
+    "dataeier": "Artsdatabanken",
     "tema": {
       "nb": "Landskap"
     },
@@ -116,7 +116,7 @@
     "tittel": {
       "nb": "Landskap: LA-I-A"
     },
-    "dataeier": "ADB",
+    "dataeier": "Artsdatabanken",
     "tema": {
       "nb": "Landskap"
     },
@@ -137,7 +137,7 @@
     "tittel": {
       "nb": "Landskap: LA-I-D"
     },
-    "dataeier": "ADB",
+    "dataeier": "Artsdatabanken",
     "tema": {
       "nb": "Landskap"
     },
@@ -158,7 +158,7 @@
     "tittel": {
       "nb": "Landskap: LA-I-S"
     },
-    "dataeier": "ADB",
+    "dataeier": "Artsdatabanken",
     "tema": {
       "nb": "Landskap"
     },
@@ -179,7 +179,7 @@
     "tittel": {
       "nb": "Landskap: LA-K-F"
     },
-    "dataeier": "ADB",
+    "dataeier": "Artsdatabanken",
     "tema": {
       "nb": "Landskap"
     },
@@ -200,7 +200,7 @@
     "tittel": {
       "nb": "Landskap: LA-K-S"
     },
-    "dataeier": "ADB",
+    "dataeier": "Artsdatabanken",
     "tema": {
       "nb": "Landskap"
     },
@@ -221,7 +221,7 @@
     "tittel": {
       "nb": "Landskap: LA-KLG-AI k"
     },
-    "dataeier": "ADB",
+    "dataeier": "Artsdatabanken",
     "tema": {
       "nb": "Landskap"
     },
@@ -242,7 +242,7 @@
     "tittel": {
       "nb": "Landskap: LA-M"
     },
-    "dataeier": "ADB",
+    "dataeier": "Artsdatabanken",
     "tema": {
       "nb": "Landskap"
     },
@@ -263,7 +263,7 @@
     "tittel": {
       "nb": "Landskap: LA-KLG-JA d"
     },
-    "dataeier": "ADB",
+    "dataeier": "Artsdatabanken",
     "tema": {
       "nb": "Landskap"
     },
@@ -284,7 +284,7 @@
     "tittel": {
       "nb": "Landskap: LA-KLG-KA k"
     },
-    "dataeier": "ADB",
+    "dataeier": "Artsdatabanken",
     "tema": {
       "nb": "Landskap"
     },
@@ -305,7 +305,7 @@
     "tittel": {
       "nb": "Landskap: LA-KLG-VP d"
     },
-    "dataeier": "ADB",
+    "dataeier": "Artsdatabanken",
     "tema": {
       "nb": "Landskap"
     },
@@ -326,7 +326,7 @@
     "tittel": {
       "nb": "Landskap: LA-KLG-BP d"
     },
-    "dataeier": "ADB",
+    "dataeier": "Artsdatabanken",
     "tema": {
       "nb": "Landskap"
     },
@@ -347,7 +347,7 @@
     "tittel": {
       "nb": "Landskap: LA-KLG-IYK d"
     },
-    "dataeier": "ADB",
+    "dataeier": "Artsdatabanken",
     "tema": {
       "nb": "Landskap"
     },
@@ -368,7 +368,7 @@
     "tittel": {
       "nb": "Landskap: LA-KLG-RE-IA d"
     },
-    "dataeier": "ADB",
+    "dataeier": "Artsdatabanken",
     "tema": {
       "nb": "Landskap"
     },
@@ -389,7 +389,7 @@
     "tittel": {
       "nb": "Landskap: LA-KLG-RE-KF-ID d"
     },
-    "dataeier": "ADB",
+    "dataeier": "Artsdatabanken",
     "tema": {
       "nb": "Landskap"
     },
@@ -410,7 +410,7 @@
     "tittel": {
       "nb": "Landskap: LA-KLG-RE-KS d"
     },
-    "dataeier": "ADB",
+    "dataeier": "Artsdatabanken",
     "tema": {
       "nb": "Landskap"
     },
@@ -432,7 +432,7 @@
     "tittel": {
       "nb": "Ferskvann: VerneplanforVassdrag"
     },
-    "dataeier": "NVE",
+    "dataeier": "Norges vassdrags- og energidirektorat",
     "tema": {
       "nb": "Ferskvann"
     },
@@ -440,16 +440,16 @@
     "kart": {
       "format": {
         "wms": {
-          "url": "https://gis3.nve.no/map/services/VerneplanforVassdrag/MapServer/WmsServer",
+          "url": "https://gis3.Norges vassdrags- og energidirektorat.no/map/services/VerneplanforVassdrag/MapServer/WmsServer",
           "layer": "VerneplanforVassdrag",
           "version": "1.3.0"
         }
       }
     },
     "featureinfo": {
-      "url": "https://gis3.nve.no/map/services/VerneplanforVassdrag/MapServer/WmsServer?QUERY_LAYERS=VerneplanforVassdrag&styles=&format=image%2Fpng&transparent=true&version=1.1.1&width=256&height=256&srs=EPSG%3A4326&request=GetFeatureInfo&service=WMS&bbox={bbox}",
+      "url": "https://gis3.Norges vassdrags- og energidirektorat.no/map/services/VerneplanforVassdrag/MapServer/WmsServer?QUERY_LAYERS=VerneplanforVassdrag&styles=&format=image%2Fpng&transparent=true&version=1.1.1&width=256&height=256&srs=EPSG%3A4326&request=GetFeatureInfo&service=WMS&bbox={bbox}",
       "tittel": "Verneplan for vassdrag",
-      "faktaark": "https://www.nve.no/vann-vassdrag-og-miljo/verneplan-for-vassdrag/"
+      "faktaark": "https://www.Norges vassdrags- og energidirektorat.no/vann-vassdrag-og-miljo/verneplan-for-vassdrag/"
     },
     "opacity": 0.9
   },

--- a/src/style/style.css
+++ b/src/style/style.css
@@ -79,6 +79,14 @@ button.active {
   text-align: center;
 }
 
+h4.container_header {
+  margin-left: 25px;
+  margin-right: 25px;
+  text-align: left;
+  border-bottom: 1px solid lightgrey;
+  padding-bottom: 5px;
+}
+
 .expand_header {
   float: left;
   width: 100%;


### PR DESCRIPTION
Nå kan den sortere seg selv og komme med overskrift!

Inntil videre har den kun sortering for dataeier, da flere tags ikke finnes og vil dukke opp i #19. Fikk en liste av @runningbones på issue #19 så tenker å se på hva av det som er lett å få inn i neste omgang, så blir det en del av den issuen, ikke denne. Samme med hvordan å velge mellom sorteringene.

Poenget er: konsept og funksjon for gruppering på plass. Ikke verdens raskeste, men den looper jo bare en gang per refresh/bytte av sortering, så tenker det er overkommelig. Ikke den mest elegante løsningen, men bør ihvertfall funke for de fleste typer tags vi kan dytte inn i settet. 
fixes #16 
