### PR TITLE
laget søk for kartlag

### DIFF
--- a/src/Forvaltningsportalen/ForvaltningsKartlag/ForvaltningsGruppering.js
+++ b/src/Forvaltningsportalen/ForvaltningsKartlag/ForvaltningsGruppering.js
@@ -9,6 +9,7 @@ const ForvaltningsGruppering = ({
   handleShowCurrent,
   show_current,
   hideHidden,
+  searchTerm,
   element
 }) => {
   return (
@@ -25,6 +26,12 @@ const ForvaltningsGruppering = ({
           showelement = true;
         }
 
+        if (searchTerm && searchTerm.length > 0) {
+          let string = JSON.stringify(element).toLowerCase();
+          if (string.indexOf(searchTerm) === -1) {
+            return null;
+          }
+        }
         if (hideHidden && !element.erSynlig) return null;
         if (!showelement) return null;
         return (

--- a/src/Forvaltningsportalen/ForvaltningsKartlag/ForvaltningsKartlag.js
+++ b/src/Forvaltningsportalen/ForvaltningsKartlag/ForvaltningsKartlag.js
@@ -9,7 +9,8 @@ class ForvaltningsKartlag extends React.Component {
   state = {
     sortcriteria: "ingen",
     filterlist: [],
-    hideHidden: false
+    hideHidden: false,
+    searchTerm: null
   };
 
   render() {
@@ -47,6 +48,18 @@ class ForvaltningsKartlag extends React.Component {
         {context => (
           <>
             <div className="sort_chooser_container">
+              <h4>Søk i kartlag</h4>
+              <input
+                type="text"
+                onChange={e => {
+                  if (e.target.value) {
+                    this.setState({
+                      searchTerm: e.target.value.toLowerCase()
+                    });
+                  }
+                }}
+              />
+
               <h4>Filtrering</h4>
 
               {Array.from(taglist).map((element, index) => {
@@ -78,7 +91,7 @@ class ForvaltningsKartlag extends React.Component {
               <h4> Filtrer bort skjulte element </h4>
               <div className="toggle">
                 <span>av</span>
-                <label class="switch">
+                <label className="switch">
                   <input
                     type="checkbox"
                     onChange={e => {
@@ -92,9 +105,8 @@ class ForvaltningsKartlag extends React.Component {
                         });
                       }
                     }}
-                    id=""
                   />
-                  <span class="slider"></span>
+                  <span className="slider"></span>
                 </label>
                 <span>på</span>
               </div>
@@ -141,6 +153,7 @@ class ForvaltningsKartlag extends React.Component {
                 .map(element => {
                   return (
                     <ForvaltningsGruppering
+                      searchTerm={this.state.searchTerm}
                       hideHidden={this.state.hideHidden}
                       filterlist={this.state.filterlist}
                       kartlag={sorted[element]}


### PR DESCRIPTION
fixes #22 

stringifier hele dict-elementet av kartlaget og kjører et ukritisk søk mot søketerm, ikke case sensitiv.
skjuler element som ikke matcher.
Ingen fancy form for markering av treff eller sånt, så om man får treff f.eks i noe som ikke vises i elementet kan det muligens se obskurt ut. men tenkte heller det enn å ikke få opp relevante ting.
