### PR TITLE
Grupperingsbug fikset

### DIFF
--- a/src/Forvaltningsportalen/ForvaltningsKartlag/ForvaltningsKartlag.js
+++ b/src/Forvaltningsportalen/ForvaltningsKartlag/ForvaltningsKartlag.js
@@ -128,37 +128,17 @@ class ForvaltningsKartlag extends React.Component {
 
                 <h4>Gruppering</h4>
 
-                <select id="sort_chooser">
-                  <option
-                    value="ingen"
-                    onClick={e => {
-                      this.setState({
-                        sortcriteria: "ingen"
-                      });
-                    }}
-                  >
-                    Ingen gruppering
-                  </option>
-                  <option
-                    value="dataeier"
-                    onClick={e => {
-                      this.setState({
-                        sortcriteria: "dataeier"
-                      });
-                    }}
-                  >
-                    Dataeier
-                  </option>
-                  <option
-                    value="tema"
-                    onClick={e => {
-                      this.setState({
-                        sortcriteria: "tema"
-                      });
-                    }}
-                  >
-                    Tema
-                  </option>
+                <select
+                  id="sort_chooser"
+                  onChange={e => {
+                    this.setState({
+                      sortcriteria: e.target.value.toLowerCase()
+                    });
+                  }}
+                >
+                  <option value="ingen">Ingen gruppering</option>
+                  <option value="dataeier">Dataeier</option>
+                  <option value="tema">Tema</option>
                 </select>
               </div>
             )}


### PR DESCRIPTION
Ikke rart den ikke virket, objektene hadde blitt endret fra andr e inputtyper til select og glemt å flytte eventlistenerene fra underelementene opp til selecten. Og firefox er snill nok til å gjøre det vi ber den om, mens chrome tenker "dette var jo ikke etter boka, så det støtter vi ikke nei!". De har litt forskjellig visjon der. Anyhow, burde virke i deres andre respektive nettlesere igjen nå.

fixes #150