### PR TITLE
Fix: Klikktekst2 med tomme variabler vises ikke

### DIFF
--- a/src/Forvaltningsportalen/FeatureInfo/GeneriskElement.js
+++ b/src/Forvaltningsportalen/FeatureInfo/GeneriskElement.js
@@ -27,15 +27,6 @@ const GeneriskElement = props => {
   const primaryText = formatterKlikktekst(kartlag.klikktekst, resultat);
   const secondaryText = formatterKlikktekst(kartlag.klikktekst2, resultat);
 
-  let secondaryTextResults = false;
-  if (
-    secondaryText.harData &&
-    secondaryText.elementer.length > 0 &&
-    secondaryText.elementer[0]
-  ) {
-    secondaryTextResults = true;
-  }
-
   return (
     <div
       style={{ backgroundColor: faktaark_url && open ? "#fff" : "#eeeeee" }}
@@ -79,7 +70,7 @@ const GeneriskElement = props => {
                 : "Ingen treff"}
             </div>
             <div className="generic-element-secondary-text">
-              {secondaryTextResults ? secondaryText.elementer : kartlag.tittel}
+              {secondaryText.harData ? secondaryText.elementer : kartlag.tittel}
             </div>
             <div className="generic-element-data-owner">{kartlag.dataeier}</div>
           </div>

--- a/src/Forvaltningsportalen/FeatureInfo/Klikktekst.js
+++ b/src/Forvaltningsportalen/FeatureInfo/Klikktekst.js
@@ -54,7 +54,7 @@ const formatterKlikktekst = (formatstring = "", input) => {
     if (e.literal) return e.literal;
     return null;
   });
-  const harData = elementer.every(e => e !== null);
+  const harData = elementer.some(e => e !== null);
   return {
     harData,
     elementer


### PR DESCRIPTION
I tilfelle Livsmiljø inneholder klikktekst2 en liste med variabler hvor bare en av dem er satt. Vis klikkteksten også når noen variabler ikke ble "funnet".